### PR TITLE
Extend object tree with creation and destruction helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# Object Namespace
-
-An object-based hierarchy that exposes kernel services through a single
-tree.  The `object_namespace.d` and `object_validator.d` sources are
-kept here directly when the namespace logic is developed in its own
-repository.
 # anonymos-object-tree
+
+This repository hosts an object-based namespace for a custom operating system. The
+layout mirrors the design used in the Norost project but is intended to integrate
+with the [internetcomputer](https://github.com/Jonathan-R-Anderson/internetcomputer)
+codebase.
+
+Kernel services are exposed as nodes in a single tree. Each node can store methods
+and properties that are accessible through the object path. Recent updates add
+recursive cleanup and helpers like `obj_remove`, `obj_create_path` and
+`obj_destroy_path` so that nodes may be dynamically created or destroyed at
+runtime.
+
+The main logic resides in `kernel/object_namespace.d` while
+`kernel/object_validator.d` performs A\* search to verify the tree is acyclic.
+The code is written in D and compiles with `ldc2` when the required kernel
+headers are available.
+
+

--- a/kernel/object_namespace.d
+++ b/kernel/object_namespace.d
@@ -35,6 +35,21 @@ struct Object {
     size_t propCapacity;
 }
 
+private void free_object_recursive(Object* obj)
+{
+    if(obj is null) return;
+    auto child = obj.child;
+    while(child !is null)
+    {
+        auto next = child.sibling;
+        free_object_recursive(child);
+        child = next;
+    }
+    if(obj.methods !is null) free(obj.methods);
+    if(obj.properties !is null) free(obj.properties);
+    free(obj);
+}
+
 __gshared Object* rootObject;
 
 private bool str_eq(const(char)* a, const(char)* b)
@@ -69,6 +84,28 @@ extern(C) void obj_add_child(Object* parent, Object* child)
     child.parent = parent;
     child.sibling = parent.child;
     parent.child = child;
+}
+
+private void unlink_child(Object* parent, Object* child)
+{
+    if(parent is null || child is null) return;
+    if(parent.child is child)
+    {
+        parent.child = child.sibling;
+        return;
+    }
+    auto c = parent.child;
+    while(c !is null && c.sibling !is child)
+        c = c.sibling;
+    if(c !is null)
+        c.sibling = child.sibling;
+}
+
+extern(C) void obj_remove(Object* obj)
+{
+    if(obj is null || obj is rootObject) return;
+    unlink_child(obj.parent, obj);
+    free_object_recursive(obj);
 }
 
 extern(C) int obj_add_method(Object* obj, const(char)* name, ObjMethodFunc func)
@@ -147,6 +184,49 @@ extern(C) Object* obj_lookup(const(char)* path)
         if(path[i] == '/') i++;
     }
     return cur;
+}
+
+private Object* ensure_path(const(char)* path, bool createMissing)
+{
+    if(path is null || path[0] != '/') return null;
+    auto cur = rootObject;
+    size_t i = 1;
+    char[64] nameBuf;
+    while(cur !is null && path[i] != 0)
+    {
+        size_t j = 0;
+        while(path[i] != '/' && path[i] != 0 && j < nameBuf.length-1)
+            nameBuf[j++] = path[i++];
+        nameBuf[j] = 0;
+        if(j == 0)
+        {
+            if(path[i] == '/') i++;
+            continue;
+        }
+        auto next = find_child(cur, nameBuf.ptr);
+        if(next is null)
+        {
+            if(!createMissing) return null;
+            next = obj_create(nameBuf.ptr);
+            obj_add_child(cur, next);
+        }
+        cur = next;
+        if(path[i] == '/') i++;
+    }
+    return cur;
+}
+
+extern(C) Object* obj_create_path(const(char)* path)
+{
+    return ensure_path(path, true);
+}
+
+extern(C) int obj_destroy_path(const(char)* path)
+{
+    auto obj = ensure_path(path, false);
+    if(obj is null || obj is rootObject) return -1;
+    obj_remove(obj);
+    return 0;
 }
 
 extern(C) long obj_call(const(char)* path, const(char)* methodName, void** args, size_t nargs)


### PR DESCRIPTION
## Summary
- expand object tree to support dynamic creation and removal of objects
- add helper for creating or deleting an object at a path
- refactor freeing logic for recursive deletion
- document the project

## Testing
- `ldc2 -c kernel/object_namespace.d kernel/object_validator.d` *(fails: unable to read module `stdlib`)*

------
https://chatgpt.com/codex/tasks/task_e_686192edbff083279a79277ac73013a9